### PR TITLE
README: Update obsolete RPC ListRules command to StreamRuleNotifications

### DIFF
--- a/googleapis/rules/README.md
+++ b/googleapis/rules/README.md
@@ -23,7 +23,7 @@ As an example, to list your rules:
 
 ```
 # cd to the cli directory
-$ python3 rule_cmd.py ListRules -v
+$ python3 rule_cmd.py StreamRuleNotifications -v
 ```
 
 Also note that both scripts require a credentials file. Specifically, they will


### PR DESCRIPTION
```
$ python3 rule_cmd.py ListRules -v
usage: rule_cmd.py [-h] [-rid RULE_ID] [-oid OPERATION_ID] [-rp RULE_PATH] [-st START_TIME] [-et END_TIME] [-v] [-ps PAGE_SIZE] [-pt PAGE_TOKEN]
                   [-ct CONTINUATION_TIME] [-o OUTPUT]
                   rpc
rpc request was not recognized: ListRules
```
```
$ python3 rule_cmd.py -v ListRules --help
usage: rule_cmd.py [-h] [-rid RULE_ID] [-oid OPERATION_ID] [-rp RULE_PATH] [-st START_TIME] [-et END_TIME] [-v] [-ps PAGE_SIZE] [-pt PAGE_TOKEN]
                   [-ct CONTINUATION_TIME] [-o OUTPUT]
                   rpc

positional arguments:
  rpc                   allowed commands: ['StreamRuleNotifications', 'StreamDetections']

```